### PR TITLE
Print template class name with errors

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install -U pip
     - pip install -U tox tox-pyenv
-    - pyenv local 2.7.10 3.5.0
+    - pyenv local 2.7.10 3.5.1
 
 test:
   override:

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -186,14 +186,22 @@ class JetstreamTemplate(object):
                 except KeyError:
                     pass
 
-        original_template = tmpl.to_json(sort_keys=False)
-        parsed_template = json.loads(original_template)
-        encoded_template = json.dumps(
-            parsed_template,
-            sort_keys=False, indent=4,
-            cls=JetstreamEncoder)
+        try:
+            # sometimes, tmpl.to_json throws an exception
+            original_template = tmpl.to_json(sort_keys=False)
+            parsed_template = json.loads(original_template)
+            encoded_template = json.dumps(
+                parsed_template,
+                sort_keys=False, indent=4,
+                cls=JetstreamEncoder)
 
-        return encoded_template
+            return encoded_template
+        except:
+            _, excep, trace = sys.exc_info()
+            class_name = type(self).__name__
+            message = "Failed to build JSON for template %s: %s" % (class_name, str(excep))
+            raise RuntimeError, message, trace
+
 
 TOP_LEVEL_DICT_ORDER = [
     'AWSTemplateFormatVersion', 'Description', 'Metadata',

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -199,7 +199,8 @@ class JetstreamTemplate(object):
         except:
             _, excep, trace = sys.exc_info()
             class_name = type(self).__name__
-            message = "Failed to build JSON for template %s: %s" % (class_name, str(excep))
+            message = "Failed to build JSON for template %s: %s" \
+                % (class_name, str(excep))
             raise RuntimeError, message, trace
 
 


### PR DESCRIPTION
Show the actual class name of the Jetstream template subclass when there's an error in JSON parsing or the `.to_json()` method. This helps immensely if there's an issue in building the template; without it, there's no way to know which template broke.