### PR TITLE
Upgrade to Troposphere 1.8.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-troposphere==1.8.1
+troposphere==1.8.2
 pyyaml
 awscli
 boto

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere==1.8.1',
+    'troposphere==1.8.2',
     'boto3==1.4.0',
     'awacs',
 ]


### PR DESCRIPTION
```
Release 1.8.2

Add SpotPrice to SpotFleet LaunchSpecifications
Add new properties to ECS (Clustername to Cluster and Family to TaskDefinition)
Add Alias object to KMS (fixes #568)
Added cross-stack references (#569)
Handle lambda => awslambda mapping in cfn2py (#573)
Add support for Tags to Certificate Manager Certificates (#574)
Adding enhanced monitoring to rds.DBInstance (#575)
Add support for LogGroupName in Logs::LogGroup (#576)
Update Export param (#579)
Add support for Fn::Sub (#582)
RDS DBInstance Engine required even when DBSnapshotIdentifier is set (#583)
Resource updates for 2016-10-06 changes (Fixes #584)
Add AWS::ApiGateway::UsagePlan (fixes #585)
Add AWS::CodeCommit::Repository (fixes #586)
Provide better type checking for values in from_dict (#587)
Allow HelperFn in UpdatePolicy for ASG (#588)
Fixed from_dict case where you have a list of non BaseAWSObjects (#589)
```