### PR TITLE
Upgrade Troposphere and boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-troposphere==1.8.2
+troposphere==1.9.0
 pyyaml
 awscli
 boto

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere==1.8.2',
-    'boto3==1.4.0',
+    'troposphere==1.9.0',
+    'boto3==1.4.1',
     'awacs',
 ]
 


### PR DESCRIPTION
```
1.9.0 (2016-11-15)

Note: the dynamodb change below may cause backwards compatibility issues. There have been deprecation warnings for a while.
Replace dynamodb module with dynamodb2 (#564)
Add CodeCommit as a supported AWS resource type
Add update of github Releases page to RELEASE doc
Update elasticache for 2016-10-12 changes (#592)
Support for S3 Lifecycle Rule property NoncurrentVersionTransitions (#596)
Include resource title in required attr exception (#597)
Added Placement class for the Placement property in LaunchSpecifications. (#598)
Add EFS example (#601)
Add support to old mysql db engine (#602)
Fix typo in Example Allowed Values (#603)
Remove title validation. Fixes #428 (#605)
Add support for conditions in cfn2py script (#606)
Added MongoDB default port to constants (#608)
Add HttpVersion prop to DistributionConfig (CloudFront HTTP/2 Support) (#609)
Added missing QueryStringCacheKeys property to CloudFront ForwardedValues (#612)
Add a validator for ELB names (#615)
```