### PR TITLE
Add prepare hooks for jetstream operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,9 @@ A --> B -> C
       |    |
       | ----> D
 ```
+
+If you extend the Jetstream template class, you can implement the following
+methods to hook into jetstream's behavior from your subclass:
+- `def prepare_document(self):` run before template documentation is generated
+- `def prepare_generate(self):` run before template is generated
+- `def prepare_test(self):` run before template is tested

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -125,6 +125,21 @@ class JetstreamTemplate(object):
         self._resource_name = None
         self.test_params = None
 
+    def prepare_document(self):
+        '''Lifecycle hook in case template wants to do any additional work'''
+        # override this method to run anything
+        pass
+
+    def prepare_generate(self):
+        '''Lifecycle hook in case template wants to do any additional work'''
+        # override this method to run anything
+        pass
+
+    def prepare_test(self):
+        '''Lifecycle hook in case template wants to do any additional work'''
+        # override this method to run anything
+        pass
+
     def _required_attrs(self, attrs):
         '''Validate that required attrs were set in a template'''
         for attr in attrs:
@@ -153,6 +168,8 @@ class JetstreamTemplate(object):
 
     def document(self):
         '''Returns documentation for the template'''
+        self.prepare_document()  # prepare template
+
         self._required_attrs(['template', 'name'])
         doc = []
         header_text = "{} FAWS Template".format(self.resource_name())
@@ -175,6 +192,7 @@ class JetstreamTemplate(object):
 
     def generate(self, testing=False):
         '''Returns the generated cf template'''
+        self.prepare_generate()  # prepare template
 
         # validation steps and proper resource name
         self._required_attrs(['template', 'name'])

--- a/jetstream/testing.py
+++ b/jetstream/testing.py
@@ -166,6 +166,8 @@ def _recurse_dependencies(templates):
     '''Flattens templates by recursively going through templates'''
     flattened_templ = {}
     for templ in templates:
+        templ.prepare_test()  # testing hook may add dependencies
+
         if not flattened_templ.get(templ.name):
             flattened_templ[templ.name] = templ
         if templ.test_params.dependencies():


### PR DESCRIPTION
Introduce prepare hooks that subclasses can use, for the three operations it performs (documentation, template generation, and testing).