### PR TITLE
Update Troposphere to 1.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-troposphere==1.9.0
+troposphere==1.9.1
 pyyaml
 awscli
 boto

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere==1.9.0',
+    'troposphere==1.9.1',
     'boto3==1.4.1',
     'awacs',
 ]


### PR DESCRIPTION
```
1.9.1 (2017-01-03)

Improve readability of AssumeRolePolicyDocument attribute (#591)
Add Environment to Lambda Function (#616)
Adding DataSources to OpsWorks App and RdsDbInstances to OpsWorks Stack (#621)
Added SNS::Subscription resource (SubscriptionResource) (#622)
Added CodeBuild Project resource and a CodeBuild example (#624)
Add back support for Python 2.6 (#626)
Fixed missing add_resource in example Cloudwatch rule (#629)
Create new property Environment for aws lambda Function (#631)
Add KmsKeyArn to Lambda Function
Add CopyTagsToSnapshot to RDS::DBInstance
Fix pycodestyle issues with examples/Lambda.py
Add AWS::SSM::Association
Add AWS::EC2::SubnetCidrBlock and AWS::EC2::VPCCidrBlock
Add mutually_exclusive validator
Add DocumentType to AWS::SSM::Document
Add OpsWorks Resources: UserProfile and Volume
Update opsworks per 2016-11-22 changes
Allow both dict and string for opswork CustomJson
Add IPv6 support from 2016-12-01 update
```