### PR TITLE
Catch more JSON serialization errors

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -47,10 +47,14 @@ def _execute(args):
         print("No updated templates found")
         return
 
+    # build the test parameters, even if we don't run tests, to catch errors
+    # where JSON can't be generated / objects can't be serialized
+    test = testing.Test(updated_templates)
+    test.parent_template()
+
     # If the test flag is set then run a test
     test_passed = True
     if args.test and updated_templates:
-        test = testing.Test(updated_templates)
         try:
             test_passed = test.run()
         except (KeyboardInterrupt, SystemExit):

--- a/jetstream/testing.py
+++ b/jetstream/testing.py
@@ -51,7 +51,7 @@ class Test(object):
 
         LOG.info("Uploading files")
         self.s3_publisher.publish_file('master.template',
-                                       self._parent_template())
+                                       self.parent_template())
         for templ in self.templates:
             LOG.info("Uploading file: %s", templ.name)
             self.s3_publisher.publish_file(templ.name,
@@ -114,7 +114,7 @@ class Test(object):
             TemplateURL=parent_templ,
             Capabilities=['CAPABILITY_IAM'])
 
-    def _parent_template(self):
+    def parent_template(self):
         '''
         Generate the parent template for the test
         '''


### PR DESCRIPTION
Try to build the master template, even if we don't actually run tests, so that we catch TestParameters and things that don't serialize. This helps us find errors locally before they run in CI.