### PR TITLE
Fixing md rendering for outputs

### DIFF
--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -191,7 +191,7 @@ class JetstreamTemplate(object):
                 doc.append("- {}: `{}`".format(prop, value))
 
         # Outputs
-        doc.append('###Outputs')
+        doc.append('\n###Outputs')
         for name in self.template.outputs.keys():
             doc.append("- `{}`".format(name))
 


### PR DESCRIPTION
This closes #29. Fixes the issue where the output
heading doesn't render properly when viewed in
GitHub.