### PR TITLE
Update object comparison to ignore order

### DIFF
--- a/jetstream/publisher.py
+++ b/jetstream/publisher.py
@@ -58,7 +58,7 @@ class S3Publisher(object):
             body = resp.get('Body')
             body_obj = json.load(body)
             latest_obj = json.loads(latest)
-            return bool(cmp(latest_obj, body_obj))
+            return not _objects_match(latest_obj, body_obj)
         except botocore.exceptions.ClientError as excep:
             if 'specified key does not exist' in str(excep):
                 return True
@@ -105,7 +105,7 @@ class LocalPublisher(object):
             existing = json.load(fil)
             fil.close()
             latest_obj = json.loads(latest)
-            return bool(cmp(latest_obj, existing))
+            return not _objects_match(latest_obj, existing)
         except IOError as excep:
             if 'No such file or directory:' not in str(excep):
                 raise excep
@@ -119,3 +119,37 @@ class LocalPublisher(object):
             return
         with open(file_path, 'w+') as fil:
             fil.write(contents)
+
+
+def _objects_match(original, latest):
+    '''
+    Validate whether two Python objects match.
+
+    For dictionaries it will verify that objects match even if
+    dictionaries are unordered.
+    '''
+
+    # If types do not match then the objects do not
+    # match
+    if not isinstance(original, type(latest)):
+        return False
+
+    if isinstance(original, dict):
+        u_keys = set(original.keys()).symmetric_difference(set(latest.keys()))
+        if len(u_keys) > 0:
+            return False
+
+        for key in original.keys():
+            if not _objects_match(original[key], latest[key]):
+                return False
+
+        return True
+    if isinstance(original, (tuple, list)):
+        if len(original) != len(latest):
+            return False
+        for i in range(0, len(original)-1):
+            if not _objects_match(original[i], latest[i]):
+                return False
+        return True
+    else:
+        return original == latest


### PR DESCRIPTION
When comparing two CloudFormation templates we should only care if a
change is not ordering related.

For example:
obj1 = {"foo": "bar", "baz": "foo"}
obj2 = {"baz": "foo", "foo": "bar"}

When the above two objects are compared the should return as a match however
they are not a literal match when using the cmp() function due to the
order.