### PR TITLE
Support publishing to specific S3 Path

### DIFF
--- a/jetstream/testing.py
+++ b/jetstream/testing.py
@@ -49,7 +49,7 @@ class Test(object):
                 path.join(os.getcwd(), self._bucket))
         else:
             self._client = boto3.client('cloudformation')
-            self.publisher = S3Publisher(self._bucket, public=False)
+            self.publisher = S3Publisher("s3://" + self._bucket, public=False)
 
     def run(self):
         '''Run the test'''


### PR DESCRIPTION
Requires a correct S3 path to publish templates to but adds the ability
to publish templates into S3 with a directory structure such as
s3://mycftemplates/production/templates.