### PR TITLE
Handle SIGTERM and clean up work

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -79,8 +79,16 @@ def _execute(args):
         sys.exit(1)
 
 
+def signal_term_handler(_signal, _frame):
+    '''Exit, throwing SystemExit automatically causing cleanup'''
+    sys.exit(1)
+
+
 def main():
     '''Main function'''
+    import signal
+    signal.signal(signal.SIGTERM, signal_term_handler)
+
     import argparse
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
- Add a signal handler for SIGTERM
- Call sys.exit in the handler, throwing SystemExit and triggering the cleanup code.

I confirmed this worked locally using `kill -TERM <pid>` while running the testing locally.