### PR TITLE
Update Troposphere to 1.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-troposphere==1.9.2
+troposphere==1.9.3
 pyyaml
 awscli
 boto

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere==1.9.2',
+    'troposphere==1.9.3',
     'boto3==1.4.4',
     'awacs',
 ]


### PR DESCRIPTION
```
1.9.3 (2017-04-13)

Fix pycodestyle by using an explicit exception type
Add more details to pycodestyle errors for travis runs
Fix validator function exception test
Remove limit check on conditions - Fixes #657
Allow valid value for TargetGroup HealthCheckPort (#659)
Added step functions and basic tests (#661)
Adding example for CloudTrail (from http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudtrail-trail.html) (#667)
Fix ApiGateway.py sample (#666)
Update comment on type checking
Added missing props to ec2.NetworkInterfaces (#669) (#670)
Add WAF Common Attacks Sample (#675)
Updated constants with new instance types (#674)
SSM Targets - fix spelling mistake (Value => Values) (#673)
Do json validation on ApiGateway::Model Schema (Fix #679) (#681)
SQS: Add FifoQueue and ContentBasedDeduplication (#687)
VPCPeeringConnection: add PeerOwnerId & PeerRoleArn (#688)
IAM: Add InstanceProfileName to InstanceProfile (#689)
Add ApiGateway UsagePlanKey resource
Add DeadLetterConfig property to Lambda::Function
Add new subproperties to route53 and redshift (#690)
Route53: ChildHealthChecks is a list of strings (#690)
Fix typo in S3_Bucket_With_Versioning_And_Lifecycle_Rules.py (#693)
Allow a dict to be passed in to initalize Tags (#692)
Add SSM::Parameter
Update autoscaling example to remove rebinding (#695)
```