### PR TITLE
Don't load all files as JSON when checking for changes

### DIFF
--- a/jetstream/publisher.py
+++ b/jetstream/publisher.py
@@ -109,6 +109,7 @@ class LocalPublisher(object):
         '''
         Compares local file contents with latest
         copy to determine whether anything has changed
+        returns False if files are identical, True otherwise
         '''
         file_path = path.join(self.base_path,
                               name)
@@ -121,6 +122,15 @@ class LocalPublisher(object):
         except IOError as excep:
             if 'No such file or directory:' not in str(excep):
                 raise excep
+        except ValueError as excep:
+            if 'No JSON object could be decoded' not in str(excep):
+                raise excep
+
+            # parse as string, the JSON parser failed
+            existing = open(file_path, 'r').read()
+            return bool(cmp(latest, existing))
+
+        # fall back to saying the files are different
         return True
 
     def publish_file(self, name, contents):

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -19,7 +19,6 @@ import collections
 import json
 import copy
 
-from datetime import datetime
 from importlib import import_module
 from troposphere import GetAtt, BaseAWSObject
 
@@ -220,7 +219,6 @@ class JetstreamTemplate(object):
         header_text = "{} FAWS Template".format(self.resource_name())
         doc.append(header_text + "\n" + ('=' * len(header_text)))
         doc.append(self.template.description)
-        doc.append("Last updated on `{}`\n".format(datetime.now()))
 
         # Parameters
         doc.append('### Parameters')


### PR DESCRIPTION
- In publisher, fall back to a string diff when json module produces 'No JSON object could be decoded', fixes #52.
- Strip last updated from templates, so they aren't always changed
- In cli, track and check for updates to documentation separately from templates, fixes #53.