### PR TITLE
Be sure to close file handle

### DIFF
--- a/jetstream/publisher.py
+++ b/jetstream/publisher.py
@@ -127,7 +127,8 @@ class LocalPublisher(object):
                 raise excep
 
             # parse as string, the JSON parser failed
-            existing = open(file_path, 'r').read()
+            with open(file_path, 'r') as fh:
+                existing = fh.read()
             return bool(cmp(latest, existing))
 
         # fall back to saying the files are different


### PR DESCRIPTION
Be sure to close filehandle, part of eb3c39fee927b6a9db4befe7a9cb88352f498329. RE: #53, #54