### PR TITLE
Add optional format selector for YAML or JSON

### DIFF
--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -39,7 +39,7 @@ def _execute(args):
     updated_templates = []
     updated_documentation = []
     for _, tmpl in templates.items():
-        if publish.newer(tmpl.name, tmpl.generate()):
+        if publish.newer(tmpl.name, tmpl.generate(format=args.format)):
             updated_templates.append(tmpl)
 
         if args.document:
@@ -80,7 +80,10 @@ def _execute(args):
             print("No publish set ... not publishing")
         else:
             for tmpl in updated_templates:
-                publish.publish_file(tmpl.name, tmpl.generate())
+                publish.publish_file(
+                    tmpl.name,
+                    tmpl.generate(format=args.format)
+                )
 
             if args.document:
                 for tmpl in updated_documentation:
@@ -140,6 +143,9 @@ def main():
     parser.add_argument('--public', action='store_true',
                         help='Whether S3 Published documents should be public',
                         default=False)
+    parser.add_argument('--format', '-f', dest='format',
+                        help='json or yaml format',
+                        default='json')
 
     test_conditions = ['never', 'failure', 'pass']
     cleanup_help = "Test condition to cleanup ({}) defaults to pass".format(

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -39,7 +39,7 @@ def _execute(args):
     updated_templates = []
     updated_documentation = []
     for _, tmpl in templates.items():
-        if publish.newer(tmpl.name, tmpl.generate(format=args.format)):
+        if publish.newer(tmpl.name, tmpl.generate(fmt=args.format)):
             updated_templates.append(tmpl)
 
         if args.document:
@@ -82,7 +82,7 @@ def _execute(args):
             for tmpl in updated_templates:
                 publish.publish_file(
                     tmpl.name,
-                    tmpl.generate(format=args.format)
+                    tmpl.generate(fmt=args.format)
                 )
 
             if args.document:
@@ -145,6 +145,7 @@ def main():
                         default=False)
     parser.add_argument('--format', '-f', dest='format',
                         help='json or yaml format',
+                        choices=['json', 'yaml'],
                         default='json')
 
     test_conditions = ['never', 'failure', 'pass']

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -21,6 +21,7 @@ import copy
 
 from importlib import import_module
 from troposphere import GetAtt, BaseAWSObject
+import cfn_flip
 
 
 def load_template(package, template):
@@ -234,7 +235,7 @@ class JetstreamTemplate(object):
 
         return "\n".join(doc)
 
-    def generate(self, testing=False):
+    def generate(self, testing=False, fmt='json'):
         '''Returns the generated cf template'''
         self.prepare_generate()  # prepare template
 
@@ -254,12 +255,21 @@ class JetstreamTemplate(object):
                     pass
 
         try:
-            # Handle JSON.dumps failing
-            encoded_template = json.dumps(
-                tmpl.to_dict(),
-                sort_keys=False, indent=2,
-                separators=(',', ': '),
-                cls=JetstreamEncoder)
+            if fmt == 'json':
+                # Handle JSON.dumps failing
+                encoded_template = json.dumps(
+                    tmpl.to_dict(),
+                    sort_keys=False, indent=2,
+                    separators=(',', ': '),
+                    cls=JetstreamEncoder)
+            elif fmt == 'yaml':
+                encoded_template = cfn_flip.to_yaml(json.dumps(
+                    tmpl.to_dict(),
+                    sort_keys=False, indent=2,
+                    separators=(',', ': '),
+                    cls=JetstreamEncoder))
+            else:
+                raise RuntimeError('unrecognized format {}'.format(fmt))
 
             return encoded_template
         except:

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -255,21 +255,15 @@ class JetstreamTemplate(object):
                     pass
 
         try:
-            if fmt == 'json':
-                # Handle JSON.dumps failing
-                encoded_template = json.dumps(
-                    tmpl.to_dict(),
-                    sort_keys=False, indent=2,
-                    separators=(',', ': '),
-                    cls=JetstreamEncoder)
-            elif fmt == 'yaml':
-                encoded_template = cfn_flip.to_yaml(json.dumps(
-                    tmpl.to_dict(),
-                    sort_keys=False, indent=2,
-                    separators=(',', ': '),
-                    cls=JetstreamEncoder))
-            else:
-                raise RuntimeError('unrecognized format {}'.format(fmt))
+            # Handle JSON.dumps failing
+            encoded_template = json.dumps(
+                tmpl.to_dict(),
+                sort_keys=False, indent=2,
+                separators=(',', ': '),
+                cls=JetstreamEncoder)
+
+            if fmt == 'yaml':
+                encoded_template = cfn_flip.to_yaml(encoded_template)
 
             return encoded_template
         except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyyaml
 awscli
 boto
 awacs
+cfn_flip

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ DEPENDENCIES = [
     'troposphere==1.9.3',
     'boto3==1.4.4',
     'awacs',
+    'cfn_flip'
 ]
 
 STYLE_REQUIRES = [


### PR DESCRIPTION
- Add new CLI option `-f` or `--format`, legal values are `yaml` or `json`, default to `json`
- Add cfn_flip to produce YAML from JSON, currently recommended way (RE: https://github.com/cloudtools/troposphere/issues/567)
- Add conditional for the new CLI option; tested & confirmed YAML is produced