### PR TITLE
Remove unused dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ troposphere==1.9.6
 pyyaml
 awscli
 boto
-awacs
 cfn_flip

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from setuptools import setup, find_packages
 DEPENDENCIES = [
     'troposphere==1.9.6',
     'boto3==1.4.4',
-    'awacs',
     'cfn_flip'
 ]
 


### PR DESCRIPTION
awacs is likely a holdover dependency from a previous incarnation of
this project that was never cleaned up. No code is importing it or
referencing it so it should not be listed as a dependency.