### PR TITLE
Troposphere released v2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-troposphere>=2.0.2
+troposphere>=2.1.0
 pyyaml
 awscli
 boto

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere>=2.0.2',
+    'troposphere>=2.1.0',
     'boto3==1.4.4',
     'cfn_flip'
 ]


### PR DESCRIPTION
Fixes a number of bugs we filed upstream:

https://github.com/cloudtools/troposphere/issues/868
and
https://github.com/cloudtools/troposphere/pull/877
