### PR TITLE
Update Jetstream to support Python3 in addition to Python2

### DIFF
--- a/jetstream/publisher.py
+++ b/jetstream/publisher.py
@@ -17,6 +17,7 @@
 import json
 import re
 import os
+import collections
 from os import path
 from logging import getLogger
 
@@ -64,7 +65,7 @@ class S3Publisher(object):
             body = resp.get('Body')
             body_obj = json.load(body)
             latest_obj = json.loads(latest)
-            return bool(cmp(latest_obj, body_obj))
+            return _updated(latest_obj, body_obj)
         except botocore.exceptions.ClientError as excep:
             if 'specified key does not exist' in str(excep):
                 return True
@@ -118,7 +119,7 @@ class LocalPublisher(object):
             existing = json.load(fil)
             fil.close()
             latest_obj = json.loads(latest)
-            return bool(cmp(latest_obj, existing))
+            return _updated(latest_obj, existing)
         except IOError as excep:
             if 'No such file or directory:' not in str(excep):
                 raise excep
@@ -129,7 +130,7 @@ class LocalPublisher(object):
             # parse as string, the JSON parser failed
             with open(file_path, 'r') as fh:
                 existing = fh.read()
-            return bool(cmp(latest, existing))
+            return _updated(latest, existing)
 
         # fall back to saying the files are different
         return True
@@ -142,3 +143,21 @@ class LocalPublisher(object):
             return
         with open(file_path, 'w+') as fil:
             fil.write(contents)
+
+
+def _sort_dict(dikt):
+    '''Recursively sort dict'''
+    for key in dikt.keys():
+        if isinstance(dikt[key], dict):
+           dikt[key] = _sort_dict(dikt[key])
+
+    return collections.OrderedDict(sorted(dikt.items()))
+
+
+def _updated(a, b):
+    if not isinstance(a, type(b)):
+        return True
+    if isinstance(a, dict):
+        return not _sort_dict(a) == _sort_dict(b)
+
+    return not a == b

--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -23,6 +23,11 @@ from importlib import import_module
 from troposphere import GetAtt, BaseAWSObject
 import cfn_flip
 
+try:
+  basestring
+except NameError:
+  basestring = str
+
 
 def load_template(package, template):
     '''
@@ -36,7 +41,7 @@ def load_template(package, template):
     except:
         _, excep, trace = sys.exc_info()
         message = "Failed to load template %s: %s" % (template, str(excep))
-        raise RuntimeError, message, trace
+        raise RuntimeError(message, trace)
 
 
 def load_templates(package):
@@ -271,7 +276,7 @@ class JetstreamTemplate(object):
             class_name = type(self).__name__
             message = "Failed to build JSON for template %s: %s" \
                 % (class_name, str(excep))
-            raise RuntimeError, message, trace
+            raise RuntimeError(message, trace)
 
 
 TOP_LEVEL_DICT_ORDER = [

--- a/test_templates/ec2_instance.py
+++ b/test_templates/ec2_instance.py
@@ -21,7 +21,7 @@ from troposphere import Parameter, Ref, Tags, Template
 from troposphere.ec2 import Instance
 from troposphere.iam import InstanceProfile, Role, Policy
 
-from s3_bucket import S3Bucket
+from test_templates.s3_bucket import S3Bucket
 
 
 class EC2Instance(JetstreamTemplate):


### PR DESCRIPTION
This updates Jetstream to work with both Python 2 and 3.