### PR TITLE
Update dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-troposphere>=2.1.0
+troposphere>=2.3.1
 pyyaml
 awscli
 boto
-cfn_flip==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,8 @@ import re
 from setuptools import setup, find_packages
 
 DEPENDENCIES = [
-    'troposphere>=2.1.0',
+    'troposphere>=2.3.1',
     'boto3==1.4.8',
-    'cfn_flip==0.2.5'
 ]
 
 STYLE_REQUIRES = [


### PR DESCRIPTION
Unpinning CFN Flip since it is pulled in by troposphere and bumping
troposphere to latest stable.