### PR TITLE
Adjust boto3 pinning to allow more recent versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 troposphere>=2.3.1
 pyyaml
 awscli
-boto
+boto3>=1.4.8

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 DEPENDENCIES = [
     'troposphere>=2.3.1',
-    'boto3==1.4.8',
+    'boto3>=1.4.8',
 ]
 
 STYLE_REQUIRES = [


### PR DESCRIPTION
This will allow more recent versions of boto3 to be used, and allows access to recently implemented methods in projects utilizing jetstream.