### PR TITLE
Ensure further randomization on test bucket naming

### DIFF
--- a/jetstream/testing.py
+++ b/jetstream/testing.py
@@ -15,11 +15,10 @@
 '''Testing module'''
 
 import time
-import os
 import string
 import random
 
-from os import path
+from os import path, getcwd, environ
 from logging import getLogger
 from troposphere import Template
 from troposphere.cloudformation import Stack
@@ -55,7 +54,7 @@ class Test(object):
 
         if self._dry_run:
             self.publisher = LocalPublisher(
-                path.join(os.getcwd(), self._bucket))
+                path.join(getcwd(), self._bucket))
         else:
             self._client = boto3.client('cloudformation')
             self.publisher = S3Publisher("s3://" + self._bucket, public=False)
@@ -68,7 +67,7 @@ class Test(object):
         :return: Either the region defined in the environment variable or False
         """
         for region_env in ["AWS_DEFAULT_REGION", "DEFAULT_REGION", "REGION"]:
-            region = os.environ.get(region_env)
+            region = environ.get(region_env)
             if region:
                 return region
 
@@ -97,10 +96,10 @@ class Test(object):
 
         if self._dry_run:
             return True
-        else:
-            LOG.info("Creating stack %s...", self._stack_name)
-            self._build_stack()
-            return self._wait_results(self._stack_name)
+
+        LOG.info("Creating stack %s...", self._stack_name)
+        self._build_stack()
+        return self._wait_results(self._stack_name)
 
     def cleanup(self):
         '''Clean up the testing stack and bucket'''
@@ -166,7 +165,7 @@ class Test(object):
             template_url = "{}/{}".format(self._bucket_url,
                                           templ.name)
             # Create a test template for every set of test parameters
-            if len(templ.get_test_parameter_groups()) == 0:
+            if not templ.get_test_parameter_groups():
                 stack_params = {}
                 stack_params['TemplateURL'] = template_url
                 stack_name = templ.resource_name() + 'Default'

--- a/jetstream/testing.py
+++ b/jetstream/testing.py
@@ -16,6 +16,8 @@
 
 import time
 import os
+import string
+import random
 
 from os import path
 from logging import getLogger
@@ -38,8 +40,15 @@ class Test(object):
     '''
     def __init__(self, templates, dry_run=False):
         self.templates = _flatten_templates(templates)
-        timestamp = int(time.time())
-        self._bucket = "jetstream-test-{}".format(timestamp)
+
+        # S3 bucket names have to be globally unique. This helps ensure as much
+        # randomness as possible by mixing the current time in detail with an
+        # additional random string
+        timestamp = time.strftime('%Y%m%d%H%M%S', time.gmtime())
+        suffix = ''.join(
+            random.SystemRandom().choice(
+                string.ascii_lowercase + string.digits) for _ in range(10))
+        self._bucket = "jetstream-test-{}-{}".format(timestamp, suffix)
         self._stack_name = "JetstreamTest{}".format(timestamp)
         self._bucket_url = "https://s3.amazonaws.com/{}".format(self._bucket)
         self._dry_run = dry_run


### PR DESCRIPTION
I've recently seen cases where the S3 bucket name used for testing purposes conflicts. This looks to resolve the issue by adding more randomness to the bucket name through:

* Using a more detailed timestamp string
* Add additional character randomness