### PR TITLE
Update tests to explicitly set a retention policy of Delete

### DIFF
--- a/jetstream/template.py
+++ b/jetstream/template.py
@@ -250,10 +250,7 @@ class JetstreamTemplate(object):
             # but do not want to affect the original.
             tmpl = copy.deepcopy(self.template)
             for _, resource in tmpl.resources.items():
-                try:
-                    resource.resource.pop('DeletionPolicy')
-                except KeyError:
-                    pass
+                resource.resource['DeletionPolicy'] = 'Delete'
 
         try:
             # Handle JSON.dumps failing


### PR DESCRIPTION
Explicitly sets a Retention Policy of `Delete`.

Tested and confirmed RDS instances will no longer snapshot on deletion, which should help to alleviate the  failures deleting option groups.

Change necessitated by AWS changing the default behavior of some resources, such as RDS instances and Clusters.  See [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html#aws-attribute-deletionpolicy-options) for more details on the behaviors.