### PR TITLE
Addition of functionality to support ad-hoc metadata which is ignored during template compare

### DIFF
--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -19,3 +19,5 @@ __version__ = '0.1.0'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2017'
 __url__ = 'https://rackspace.com/rackerlabs/jetstream'
+
+TOPLEVEL_METADATA_KEY = 'Jetstream'

--- a/jetstream/cli.py
+++ b/jetstream/cli.py
@@ -44,7 +44,9 @@ def _execute(args):
         if args.extension:
             template_name += '.' + args.format
 
-        if publish.newer(template_name, tmpl.generate(fmt=args.format)):
+        if publish.newer(template_name, tmpl.generate(
+                fmt=args.format,
+                additional_metadata=args.additional_metadata)):
             updated_templates.append(tmpl)
 
         if args.document:
@@ -92,7 +94,8 @@ def _execute(args):
 
                 publish.publish_file(
                     template_name,
-                    tmpl.generate(fmt=args.format)
+                    tmpl.generate(fmt=args.format,
+                                  additional_metadata=args.additional_metadata)
                 )
 
             if args.document:
@@ -150,6 +153,14 @@ def main():
                         help='Do not publish CloudFormation results',
                         action='store_true',
                         default=False)
+    parser.add_argument('--metadata', '-M',
+                        dest='additional_metadata',
+                        help='Add dynamic metadata under a Jetstream key which'
+                             'is ignored for comparison purposes. This can be '
+                             'used for version numbers, date stamp, hash '
+                             'values, etc. Value is the form "key=value".',
+                        action='append',
+                        default=[])
     parser.add_argument('--public', action='store_true',
                         help='Whether S3 Published documents should be public',
                         default=False)


### PR DESCRIPTION
## Summary

This PR essentially adds the following:

* A top level key defined in `__init__.py` since it is used across multiple files in the jetstream module (currently set to `Jetstream`
* Code to remove toplevel key from metadata during comparison 
* A CLI option (`--metadata` or `-M`) to accept ad-hoc metadata for inserting into the top level key

## Linting Fixes

Normally I'm a fan of squashing linting type fixes into commits, but there were enough to where doing so would have just made the commit history very confusing. The following checks were causing CI issues and were remediated:

* Import check for the top level metadata key. Just needed to go after boto imports.
* Fixing a too long line that didn't show any issues in the IDE. Might be a off by one error but addressed anyways.
* Fixed setting default value to list for a keyword arg. This is due to a [rather annoying quirk](https://docs.python-guide.org/writing/gotchas/) of default args.
* Fixed too many local variables in the `generate_template` function by pulling metadata generation into a static method. 

## Verification

* Ensured existing templates without the jetstream top level key would not be proc'ed as being updated
* Ensured running without the new command line arguments works (to prevent breaking backwards compat)
* Ensured running with the new command line arguments only updates the template if a non-jetstream metadata change occurred
* Ensured that all metadata values were present after a template update

## Issue

#85 