### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+0.1.1 - Thursday, February 7th 2019
+
+* Introduction of CHANGELOG to contain initial 0.1.1 commit
+* [ GH85 ] Ability to add ad-hoc metadata

--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -15,7 +15,7 @@
 '''Jetstream Init'''
 
 __title__ = 'jetstream'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2017'
 __url__ = 'https://rackspace.com/rackerlabs/jetstream'


### PR DESCRIPTION
* Addition of CHANGELOG which will start at the last ad-hoc metadata commit for now
* Bump version to 0.1.1