### PR TITLE
[ #91 ] Update jetstream to support python 2/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.2.0 - Monday, March 25th 2019
+
+* [ GH91 ] Update codebase to support python 2/3 code
+
 0.1.1 - Thursday, February 7th 2019
 
 * Introduction of CHANGELOG to contain initial 0.1.1 commit

--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -15,7 +15,7 @@
 '''Jetstream Init'''
 
 __title__ = 'jetstream'
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2017'
 __url__ = 'https://rackspace.com/rackerlabs/jetstream'

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     classifiers=[
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.7"
     ],
     license=_lu_meta['license'],
     author="Rackers",


### PR DESCRIPTION
* Bump to 0.2.0, due to the critical code reform
* Add entry to CHANGELOG
* Add Python 3.7 to metadata entry in setup.py