### PR TITLE
[ #94 ] Fix `cfn-flip` install order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
       - run: virtualenv ~/repo/venv
       - run: echo "source ~/repo/venv/bin/activate" >> $BASH_ENV
       - run: pip install --upgrade pip
-      - run: pip install -U tox tox-venv
+      - run: pip install 'tox==3.5.0'
+      - run: pip install tox-venv
       - run: cd ~/repo && tox -v
 workflows:
   version: 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+cfn_flip==1.1.0
 troposphere>=2.3.1
 pyyaml
 awscli
 boto3>=1.4.8
-cfn_flip==1.1.0


### PR DESCRIPTION
* Install `cfn-flip` before troposphere since it uses a fairly greedy version deceleration when we have it pinned to a specific version