### PR TITLE
Version bump to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+0.2.1 - Tuesday, April 2nd 2019
+
+* [ GH94 ] Update `cfn-flip` dep order to prevent version conflicts
+
 0.2.0 - Monday, March 25th 2019
 
 * [ GH91 ] Update codebase to support python 2/3 code

--- a/jetstream/__init__.py
+++ b/jetstream/__init__.py
@@ -15,7 +15,7 @@
 '''Jetstream Init'''
 
 __title__ = 'jetstream'
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2017'
 __url__ = 'https://rackspace.com/rackerlabs/jetstream'


### PR DESCRIPTION
This includes the fix for making sure that `cfn-flip` version pinning works properly