### PR TITLE
[ #98 ] Make exception catch for ValueError more generic

### DIFF
--- a/jetstream/publisher.py
+++ b/jetstream/publisher.py
@@ -160,10 +160,9 @@ class LocalPublisher(object):
         except IOError as excep:
             if 'No such file or directory:' not in str(excep):
                 raise excep
+        # ValueError works for both python 2 and 3 as the python 3 JSON
+        # decoder exception class is a subclass of ValueError
         except ValueError as excep:
-            if 'No JSON object could be decoded' not in str(excep):
-                raise excep
-
             # parse as string, the JSON parser failed
             with open(file_path, 'r') as fh:
                 existing = fh.read()


### PR DESCRIPTION
* This is due to the fact that Python3 has a different exception message but the exception itself is a base class of ValueError so this will make it more generic